### PR TITLE
Patch Release Update schema.graphqls

### DIFF
--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -33,6 +33,7 @@ input WarrantyPlanCartItem {
     term: Int!
     title: String!
     product: String!
+    offerPlanId: String!
 }
 
 type WarrantyProduct implements ProductInterface, PhysicalProductInterface, CustomizableProductInterface @doc(description: "A simple product is tangible and are usually sold as single units or in fixed quantities.")


### PR DESCRIPTION
Merchant reported an error when using graphql endpoint

Variable "$warranty" got invalid value {"planId":"B0-HGGEN-2y","price":3799,"term":24,"coverageType":"base","title":"Extend Protection Plan","offerPlanId":"ERN:OFP:d97f3758-d625-4e87-b53b-d68d6185e262","product":"P05711"}; Field "offerPlanId" is not defined by type WarrantyPlanCartItem.